### PR TITLE
fix: 收起侧边栏后所有视图统一展开把手（产物库/项目/工坊首页死路）

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import Sidebar from './components/Sidebar';
+import SidebarHandle from './components/SidebarHandle';
 import ChatArea from './components/ChatArea';
 import EditorView from './components/editor/EditorView';
 import WorkshopView from './components/workshop/WorkshopView';
@@ -314,29 +315,33 @@ function App() {
         transition={{ duration: 0.3 }}
       >
         <ProjectTopBar />
-        {activeView === 'chat' ? (
-          <ChatArea
-            isConnected={isReady && hasAnyChatProviderKey({ glmApiKey, providerApiKeys, credentials, credentialRefs })}
-            onSendMessage={sendMessage}
-            onAbort={abort}
-          />
-        ) : activeView === 'canvas' ? (
-          <CanvasView onSendMessage={sendMessage} onAbort={abort} />
-        ) : activeView === 'wechat' ? (
-          <WechatView />
-        ) : activeView === 'lark' ? (
-          <LarkView />
-        ) : activeView === 'projects' ? (
-          <ProjectListView />
-        ) : activeView === 'library' ? (
-          <ArtifactLibrary />
-        ) : activeView === 'workshop' ? (
-          <WorkshopView onSendMessage={sendMessage} onAbort={abort} />
-        ) : activeView === 'copywriting' ? (
-          <CopywritingView onSendMessage={sendMessage} onAbort={abort} />
-        ) : (
-          <EditorView onSendMessage={sendMessage} onAbort={abort} />
-        )}
+        {/* 视图区统一包一层：SidebarHandle 挂这里，所有视图共享一个展开把手，子视图零感知 */}
+        <div className="relative flex min-h-0 flex-1 flex-col">
+          <SidebarHandle />
+          {activeView === 'chat' ? (
+            <ChatArea
+              isConnected={isReady && hasAnyChatProviderKey({ glmApiKey, providerApiKeys, credentials, credentialRefs })}
+              onSendMessage={sendMessage}
+              onAbort={abort}
+            />
+          ) : activeView === 'canvas' ? (
+            <CanvasView onSendMessage={sendMessage} onAbort={abort} />
+          ) : activeView === 'wechat' ? (
+            <WechatView />
+          ) : activeView === 'lark' ? (
+            <LarkView />
+          ) : activeView === 'projects' ? (
+            <ProjectListView />
+          ) : activeView === 'library' ? (
+            <ArtifactLibrary />
+          ) : activeView === 'workshop' ? (
+            <WorkshopView onSendMessage={sendMessage} onAbort={abort} />
+          ) : activeView === 'copywriting' ? (
+            <CopywritingView onSendMessage={sendMessage} onAbort={abort} />
+          ) : (
+            <EditorView onSendMessage={sendMessage} onAbort={abort} />
+          )}
+        </div>
       </motion.div>
 
       {/* Skill Wizard Panel */}

--- a/src/components/ChatArea.tsx
+++ b/src/components/ChatArea.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
-import { AlertCircle, Menu, PanelRight } from 'lucide-react';
+import { AlertCircle, PanelRight } from 'lucide-react';
 import MessageList from './MessageList';
 import MessageInput from './MessageInput';
 import { useChatStore, useSettingsStore } from '@/stores';
@@ -37,7 +37,7 @@ export default function ChatArea({ isConnected, onSendMessage, onAbort }: ChatAr
   const decisionHistoryLength = useAskUserStore((state) => state.history.length);
 
   const currentSession = useChatStore((s) => s.sessions.find(ss => ss.id === s.currentSessionId));
-  const { sidebarCollapsed, toggleSidebar, sessionTitles } = useSettingsStore();
+  const { sidebarCollapsed, sessionTitles } = useSettingsStore();
   const { playNotification } = useSound();
   const listRef = useRef<HTMLDivElement>(null);
   const frameRef = useRef<HTMLDivElement>(null);
@@ -160,15 +160,8 @@ export default function ChatArea({ isConnected, onSendMessage, onAbort }: ChatAr
     <div className="relative flex h-full flex-col bg-[rgb(var(--c-bg))]">
       <div className="flex h-[52px] shrink-0 items-center justify-between border-b border-[rgb(var(--c-border))] px-4">
         <div className="flex min-w-0 items-center gap-2.5">
-          {sidebarCollapsed && (
-            <button
-              onClick={toggleSidebar}
-              className="flex h-8 w-8 items-center justify-center rounded-md text-[rgb(var(--c-text-muted))] transition-colors hover:bg-[rgb(var(--c-border))] hover:text-[rgb(var(--c-text))]"
-              title="展开侧栏"
-            >
-              <Menu size={17} />
-            </button>
-          )}
+          {/* 收起时留原把手等宽占位：App 层全局 SidebarHandle 浮在此处，标题不位移 */}
+          {sidebarCollapsed && <div className="h-8 w-8 shrink-0" />}
           <div className="min-w-0">
             <h1 className="flex min-w-0 items-center gap-2 text-[14px] font-medium text-[rgb(var(--c-text))]">
               <span className="truncate">{displayTitle}</span>

--- a/src/components/SidebarHandle.tsx
+++ b/src/components/SidebarHandle.tsx
@@ -1,0 +1,71 @@
+/**
+ * SidebarHandle — 侧栏收起后全局唯一的展开把手，挂在所有视图共同的父级（App 层），子视图零感知：
+ * 任何视图忘了（或没来得及）提供返回路径都不会再出现死路。
+ * 位置统一左上角（与原剪辑/画布/工坊收起把手一致）；原把手在顶栏占位的视图以等宽占位符让位。
+ * 图标与配色沿用原各视图把手：画布系用 --canvas-panel（即其顶栏底色）、文案与 chat 系用透明
+ * 幽灵钮（透出页面底色）、产物库/项目用 stone 系。主题 CSS 变量定义在主题类本身，故把手自带主题类。
+ */
+import type { ComponentType } from 'react';
+import { Menu, PanelLeftOpen } from 'lucide-react';
+import { useChatStore } from '@/stores';
+import type { ActiveView } from '@/stores/chatStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+/** 画布原把手的图标：方形 + 左侧分割线（原 CanvasView 内联 SVG） */
+const CanvasIcon = ({ size = 16 }: { size?: number | string }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="9" y1="3" x2="9" y2="21" />
+  </svg>
+);
+
+type ViewSkin = {
+  /** 主题类（提供 CSS 变量）+ 原把手配色 */
+  cls: string;
+  Icon: ComponentType<{ size?: number | string }>;
+};
+
+// 画布/工坊/剪辑：原 cv-panel cv-btn 把手（bg=--canvas-panel，恰为其顶栏底色）
+const CANVAS_SKIN_CLS =
+  'canvas-dark border border-[var(--canvas-node-border)] bg-[var(--canvas-panel)] text-[var(--canvas-text-2)] hover:bg-[var(--canvas-controls-hover)] hover:text-[var(--canvas-text-1)]';
+// chat/微信/飞书：原幽灵把手，透明底透出页面底色
+const CHAT_SKIN_CLS =
+  'text-[rgb(var(--c-text-muted))] hover:text-[rgb(var(--c-text))] hover:bg-[rgb(var(--c-border))]';
+
+// 视图 → 把手皮肤（图标+配色，沿用原把手）；不登记的视图走默认。改这里，不动任何视图。
+const VIEW_SKINS: Partial<Record<ActiveView, ViewSkin>> = {
+  chat: { cls: CHAT_SKIN_CLS, Icon: Menu },
+  wechat: { cls: CHAT_SKIN_CLS, Icon: Menu },
+  lark: { cls: CHAT_SKIN_CLS, Icon: Menu },
+  canvas: { cls: CANVAS_SKIN_CLS, Icon: CanvasIcon },
+  workshop: { cls: CANVAS_SKIN_CLS, Icon: PanelLeftOpen },
+  editor: { cls: CANVAS_SKIN_CLS, Icon: PanelLeftOpen },
+  copywriting: {
+    cls: 'copywriting-light text-[var(--cw-text-muted)] hover:text-[var(--cw-text-2)] hover:bg-[var(--cw-card)]',
+    Icon: PanelLeftOpen,
+  },
+  library: { cls: 'bg-white text-stone-500 hover:bg-stone-100', Icon: PanelLeftOpen },
+  projects: { cls: 'bg-stone-50 text-stone-500 hover:bg-stone-100', Icon: PanelLeftOpen },
+};
+const DEFAULT_SKIN: ViewSkin = {
+  cls: 'text-zinc-500 hover:text-zinc-700 hover:bg-zinc-500/10',
+  Icon: PanelLeftOpen,
+};
+
+export default function SidebarHandle() {
+  const sidebarCollapsed = useSettingsStore((s) => s.sidebarCollapsed);
+  const toggleSidebar = useSettingsStore((s) => s.toggleSidebar);
+  const activeView = useChatStore((s) => s.activeView);
+
+  if (!sidebarCollapsed) return null;
+  const { cls, Icon } = VIEW_SKINS[activeView] ?? DEFAULT_SKIN;
+
+  return (
+    <button
+      onClick={toggleSidebar}
+      className={`absolute left-3 top-3 z-30 flex h-8 w-8 items-center justify-center rounded-lg transition-colors ${cls}`}
+      title="展开侧边栏"
+    >
+      <Icon size={16} />
+    </button>
+  );
+}

--- a/src/components/canvas/CanvasView.tsx
+++ b/src/components/canvas/CanvasView.tsx
@@ -4,7 +4,6 @@ import type { Connection, Node, NodeChange, NodePositionChange } from 'reactflow
 import 'reactflow/dist/style.css';
 import '@reactflow/node-resizer/dist/style.css';
 import { useCanvasStore } from '@/stores/canvasStore';
-import { useSettingsStore } from '@/stores/settingsStore';
 import { nanoid } from 'nanoid';
 import TextNode from './nodes/TextNode';
 import ImageNode from './nodes/ImageNode';
@@ -67,8 +66,6 @@ function CanvasViewInner({ onSendMessage, onAbort }: CanvasViewProps) {
   const onEdgesChange = useCanvasStore((s) => s.onEdgesChange);
   const onConnect = useCanvasStore((s) => s.onConnect);
   const setSelectedNodeId = useCanvasStore((s) => s.setSelectedNodeId);
-  const sidebarCollapsed = useSettingsStore((s) => s.sidebarCollapsed);
-  const toggleSidebar = useSettingsStore((s) => s.toggleSidebar);
   const reactFlowWrapper = useRef<HTMLDivElement>(null);
   const { screenToFlowPosition } = useReactFlow();
   const nativeDropPointRef = useRef<{ x: number; y: number } | null>(null);
@@ -692,18 +689,6 @@ function CanvasViewInner({ onSendMessage, onAbort }: CanvasViewProps) {
             <div className="text-[var(--canvas-text-3)] text-xs">从左侧面板添加节点，或使用右下角气泡让鲲鹏帮你创建流水线</div>
           </div>
         </div>
-      )}
-
-      {sidebarCollapsed && (
-        <button
-          onClick={toggleSidebar}
-          className="absolute top-3 left-3 z-20 p-2 rounded-lg cv-panel cv-btn backdrop-blur-sm"
-          title="展开侧边栏"
-        >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <rect x="3" y="3" width="18" height="18" rx="2" /><line x1="9" y1="3" x2="9" y2="21" />
-          </svg>
-        </button>
       )}
 
       <CanvasChatBubble onSendMessage={onSendMessage} onAbort={onAbort} />

--- a/src/components/copywriting/CopywritingView.tsx
+++ b/src/components/copywriting/CopywritingView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Download, FileUp, PanelLeftOpen } from 'lucide-react';
+import { Download, FileUp } from 'lucide-react';
 import { useCopywritingStore } from '@/stores/copywritingStore';
 import { useSettingsStore } from '@/stores/settingsStore';
 import DocSidebar from './DocSidebar';
@@ -20,7 +20,6 @@ export default function CopywritingView({ onSendMessage, onAbort }: Props) {
   const updateDoc = useCopywritingStore(s => s.updateDoc);
   const [showExperience, setShowExperience] = useState(false);
   const sidebarCollapsed = useSettingsStore(s => s.sidebarCollapsed);
-  const toggleSidebar = useSettingsStore(s => s.toggleSidebar);
 
   useEffect(() => {
     if (!loaded) void loadAll();
@@ -54,18 +53,8 @@ export default function CopywritingView({ onSendMessage, onAbort }: Props) {
         className="flex items-center gap-3 px-5 py-2.5 shrink-0"
         style={{ background: 'var(--cw-bg)', borderBottom: '1px solid var(--cw-border)' }}
       >
-        {sidebarCollapsed && (
-          <button
-            onClick={toggleSidebar}
-            className="p-1.5 -ml-2 rounded-md transition-colors"
-            style={{ color: 'var(--cw-text-muted)' }}
-            onMouseEnter={e => { e.currentTarget.style.background = 'var(--cw-card)'; e.currentTarget.style.color = 'var(--cw-text-2)'; }}
-            onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; e.currentTarget.style.color = 'var(--cw-text-muted)'; }}
-            title="展开侧边栏"
-          >
-            <PanelLeftOpen size={16} />
-          </button>
-        )}
+        {/* 收起时留原把手等宽占位：App 层全局 SidebarHandle 浮于此处，标题不位移 */}
+        {sidebarCollapsed && <div className="-ml-2 w-7 shrink-0" />}
         {activeDoc ? (
           <input
             value={activeDoc.title}

--- a/src/components/editor/EditorTopBar.tsx
+++ b/src/components/editor/EditorTopBar.tsx
@@ -7,7 +7,7 @@
 import { useEffect, useRef, useState } from 'react';
 import {
   Subtitles, Download, SlidersHorizontal, Keyboard, Loader2,
-  PanelLeftOpen, PanelLeftClose, Sparkles, ChevronDown,
+  PanelLeftClose, Sparkles, ChevronDown,
 } from 'lucide-react';
 import { useEditorStore } from '@/stores/editorStore';
 import { dispatchEditorPrompt } from './EditorChatPanel';
@@ -84,13 +84,18 @@ export default function EditorTopBar({ onAutoSubtitle, onSmartCut, onAiSmooth, t
       className="flex items-center gap-1 px-3 shrink-0"
       style={{ height: 44, background: 'var(--canvas-panel)', borderBottom: '1px solid var(--canvas-node-border)' }}
     >
-      <button
-        onClick={toggleSidebar}
-        title={sidebarCollapsed ? '展开侧边栏' : '收起侧边栏'}
-        className="flex items-center px-1.5 py-1 rounded-md text-[var(--canvas-text-2)] hover:text-[var(--canvas-text-1)] hover:bg-[rgba(255,255,255,0.06)] transition-colors shrink-0"
-      >
-        {sidebarCollapsed ? <PanelLeftOpen size={14} /> : <PanelLeftClose size={14} />}
-      </button>
+      {/* 收起侧边栏；收起时留等宽占位给 App 层全局 SidebarHandle（浮于左上角），标题不位移 */}
+      {sidebarCollapsed ? (
+        <div className="w-[26px] shrink-0" />
+      ) : (
+        <button
+          onClick={toggleSidebar}
+          title="收起侧边栏"
+          className="flex items-center px-1.5 py-1 rounded-md text-[var(--canvas-text-2)] hover:text-[var(--canvas-text-1)] hover:bg-[rgba(255,255,255,0.06)] transition-colors shrink-0"
+        >
+          <PanelLeftClose size={14} />
+        </button>
+      )}
       <div className="ml-0.5 min-w-[108px]">
         <p className="text-[12px] font-semibold text-[var(--canvas-text-1)] leading-tight">鲲鹏剪辑</p>
         <p className="text-[9px] text-[var(--canvas-text-3)] leading-tight">时间线 01</p>

--- a/src/components/lark/LarkView.tsx
+++ b/src/components/lark/LarkView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Bot, Check, ChevronLeft, FileText, Loader2, Menu, MessageSquare, Paperclip, Pencil, Plus, Send, Users, X, ListChecks } from 'lucide-react';
+import { Bot, Check, ChevronLeft, FileText, Loader2, MessageSquare, Paperclip, Pencil, Plus, Send, Users, X, ListChecks } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { open } from '@tauri-apps/api/dialog';
 import { convertFileSrc, invoke } from '@tauri-apps/api/tauri';
@@ -493,17 +493,13 @@ export default function LarkView() {
   const configOpen = useLarkStore((s) => s.configOpen);
   const setConfigOpen = useLarkStore((s) => s.setConfigOpen);
   const sidebarCollapsed = useSettingsStore((s) => s.sidebarCollapsed);
-  const toggleSidebar = useSettingsStore((s) => s.toggleSidebar);
   const hasBots = Object.keys(bots).length > 0;
 
   return (
     <div className="w-full h-full flex flex-col" style={{ background: 'rgb(var(--c-bg))' }}>
+      {/* 收起时保留原把手条等高占位：App 层全局 SidebarHandle 浮于此处，内容不上移 */}
       {sidebarCollapsed && (
-        <div className="px-4 py-2 border-b" style={{ borderColor: 'rgb(var(--c-border))' }}>
-          <button onClick={toggleSidebar} className="p-2 hover:bg-dark-border rounded-lg transition-colors">
-            <Menu size={20} style={{ color: 'rgb(var(--c-text))' }} />
-          </button>
-        </div>
+        <div className="h-[52px] shrink-0 border-b" style={{ borderColor: 'rgb(var(--c-border))' }} />
       )}
       <div className="flex-1 flex min-h-0">
         {configOpen || !hasBots ? (

--- a/src/components/library/ArtifactLibrary.tsx
+++ b/src/components/library/ArtifactLibrary.tsx
@@ -12,6 +12,7 @@ import { convertFileSrc, invoke } from '@tauri-apps/api/tauri';
 import { open as openDialog, message as tauriMessage } from '@tauri-apps/api/dialog';
 import { copyFile } from '@tauri-apps/api/fs';
 import { listArtifacts, type ArtifactEntry, type ArtifactType } from '@/lib/artifacts';
+import { useSettingsStore } from '@/stores/settingsStore';
 import { useVideoThumb } from '@/lib/canvas/videoThumbs';
 import { useProjectStore } from '@/stores/projectStore';
 import { useCanvasStore } from '@/stores/canvasStore';
@@ -50,6 +51,7 @@ export default function ArtifactLibrary() {
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const projects = useProjectStore((s) => s.projects);
   const setActiveView = useChatStore((s) => s.setActiveView);
+  const sidebarCollapsed = useSettingsStore((s) => s.sidebarCollapsed);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -158,7 +160,8 @@ export default function ArtifactLibrary() {
     <div className="flex-1 flex flex-col bg-stone-50 min-h-0">
       {/* Header / filters */}
       <div className="px-8 pt-6 pb-3 border-b border-stone-200 bg-white">
-        <div className="flex items-center justify-between mb-4">
+        {/* 收起时左移让位给 App 层全局 SidebarHandle（浮于左上角，与标题同栏）；padding 不参与 justify-between 分配，标题仍左对齐 */}
+        <div className={`flex items-center justify-between mb-4${sidebarCollapsed ? ' pl-5' : ''}`}>
           <div>
             <h1 className="text-xl font-semibold text-stone-800">产物库</h1>
             <p className="text-[13px] text-stone-400 mt-0.5">

--- a/src/components/projects/ProjectListView.tsx
+++ b/src/components/projects/ProjectListView.tsx
@@ -12,6 +12,7 @@ import {
 import { open as openDialog, message as tauriMessage } from '@tauri-apps/api/dialog';
 import { useProjectStore, type Project } from '@/stores/projectStore';
 import { useChatStore } from '@/stores/chatStore';
+import { useSettingsStore } from '@/stores/settingsStore';
 import { useWorkshopStore } from '@/stores/workshopStore';
 import { useUnifiedProjectStore } from '@/stores/unifiedProjectStore';
 import { listProjects, deleteProject as deleteAigcProject, writeProject, type AigcProject } from '@/lib/aigc/projectStore';
@@ -38,6 +39,7 @@ export default function ProjectListView() {
   const canvasProjects = useProjectStore((s) => s.projects);
   const initialize = useProjectStore((s) => s.initialize);
   const setActiveView = useChatStore((s) => s.setActiveView);
+  const sidebarCollapsed = useSettingsStore((s) => s.sidebarCollapsed);
   const openUnified = useUnifiedProjectStore((s) => s.openUnified);
   const createAndOpen = useWorkshopStore((s) => s.createAndOpen);
 
@@ -215,7 +217,8 @@ export default function ProjectListView() {
   return (
     <div className="flex-1 overflow-y-auto bg-stone-50">
       <div className="max-w-5xl mx-auto px-8 py-8">
-        <div className="flex items-center justify-between mb-6">
+        {/* 收起时左移让位给 App 层全局 SidebarHandle（浮于左上角，与标题同栏）；padding 不参与 justify-between 分配，标题仍左对齐 */}
+        <div className={`flex items-center justify-between mb-6${sidebarCollapsed ? ' pl-5' : ''}`}>
           <div>
             <h1 className="text-xl font-semibold text-stone-800">项目</h1>
             <p className="text-[13px] text-stone-400 mt-0.5">

--- a/src/components/wechat/WechatView.tsx
+++ b/src/components/wechat/WechatView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { motion } from 'framer-motion';
-import { MessageSquare, Send, Loader2, QrCode, ChevronLeft, Menu, Pencil, Check, Plus, X, Paperclip, FileText, Bot, Users, ListChecks } from 'lucide-react';
+import { MessageSquare, Send, Loader2, QrCode, ChevronLeft, Pencil, Check, Plus, X, Paperclip, FileText, Bot, Users, ListChecks } from 'lucide-react';
 import { QRCodeSVG } from 'qrcode.react';
 import { open } from '@tauri-apps/api/dialog';
 import { convertFileSrc } from '@tauri-apps/api/tauri';
@@ -654,19 +654,15 @@ function ChatPanel() {
 export default function WechatView() {
   const bots = useWechatStore((s) => s.bots);
   const sidebarCollapsed = useSettingsStore((s) => s.sidebarCollapsed);
-  const toggleSidebar = useSettingsStore((s) => s.toggleSidebar);
   const [showLogin, setShowLogin] = useState(false);
 
   const hasBots = Object.keys(bots).length > 0;
 
   return (
     <div className="w-full h-full flex flex-col" style={{ background: 'rgb(var(--c-bg))' }}>
+      {/* 收起时保留原把手条等高占位：App 层全局 SidebarHandle 浮于此处，内容不上移 */}
       {sidebarCollapsed && (
-        <div className="px-4 py-2 border-b" style={{ borderColor: 'rgb(var(--c-border))' }}>
-          <button onClick={toggleSidebar} className="p-2 hover:bg-dark-border rounded-lg transition-colors">
-            <Menu size={20} style={{ color: 'rgb(var(--c-text))' }} />
-          </button>
-        </div>
+        <div className="h-[52px] shrink-0 border-b" style={{ borderColor: 'rgb(var(--c-border))' }} />
       )}
 
       <div className="flex-1 flex min-h-0">

--- a/src/components/workshop/WorkshopView.tsx
+++ b/src/components/workshop/WorkshopView.tsx
@@ -3,7 +3,7 @@
  * 顶栏 + 左 StepNav + 主区当前步骤 + 右抽屉鲲鹏助手。
  */
 import { useEffect, useRef, useState } from 'react';
-import { ArrowLeft, Clapperboard, FileUp, Loader2, PanelLeftClose, PanelLeftOpen, Plus, Sparkles, Trash2 } from 'lucide-react';
+import { ArrowLeft, Clapperboard, FileUp, Loader2, PanelLeftClose, Plus, Sparkles, Trash2 } from 'lucide-react';
 import { confirm as tauriConfirm } from '@tauri-apps/api/dialog';
 import { useWorkshopStore } from '@/stores/workshopStore';
 import { useUnifiedProjectStore } from '@/stores/unifiedProjectStore';
@@ -36,8 +36,6 @@ export default function WorkshopView({ onSendMessage, onAbort }: Props) {
   const project = useWorkshopStore((s) => s.project);
   // 只订阅 currentStep：store 任何写入都会换 data 引用，整订 data 会让整个工坊壳层每次重写
   const currentStep = useWorkshopStore((s) => s.data?.currentStep);
-  const sidebarCollapsed = useSettingsStore((s) => s.sidebarCollapsed);
-  const toggleSidebar = useSettingsStore((s) => s.toggleSidebar);
   const contentRef = useRef<HTMLDivElement>(null);
   const [altHeld, setAltHeld] = useState(false);
 
@@ -84,15 +82,6 @@ export default function WorkshopView({ onSendMessage, onAbort }: Props) {
         <>
           <TopBar />
           <div className="flex-1 flex min-h-0 relative">
-            {sidebarCollapsed && (
-              <button
-                onClick={toggleSidebar}
-                className="absolute top-3 left-3 z-30 p-2 rounded-lg cv-panel cv-btn backdrop-blur-sm"
-                title="展开侧边栏"
-              >
-                <PanelLeftOpen size={16} />
-              </button>
-            )}
             <StepNav />
             <div ref={contentRef} className="flex-1 min-w-0 overflow-y-auto relative">
               {currentStep === 'script' && <StepScript />}
@@ -133,13 +122,18 @@ function TopBar() {
       className="flex items-center gap-3 px-4 shrink-0"
       style={{ height: 48, background: 'var(--canvas-panel)', borderBottom: '1px solid var(--canvas-node-border)' }}
     >
-      <button
-        onClick={toggleSidebar}
-        className="p-2 rounded-lg text-[var(--canvas-text-2)] hover:text-[var(--canvas-text-1)] hover:bg-[var(--canvas-controls-hover)] transition-colors"
-        title={sidebarCollapsed ? '展开侧边栏' : '收起侧边栏'}
-      >
-        {sidebarCollapsed ? <PanelLeftOpen size={15} /> : <PanelLeftClose size={15} />}
-      </button>
+      {/* 收起侧边栏；收起时留等宽占位给 App 层全局 SidebarHandle（浮于左上角），后续按钮不位移 */}
+      {sidebarCollapsed ? (
+        <div className="w-[31px] shrink-0" />
+      ) : (
+        <button
+          onClick={toggleSidebar}
+          className="p-2 rounded-lg text-[var(--canvas-text-2)] hover:text-[var(--canvas-text-1)] hover:bg-[var(--canvas-controls-hover)] transition-colors"
+          title="收起侧边栏"
+        >
+          <PanelLeftClose size={15} />
+        </button>
+      )}
       <button
         onClick={close}
         className="flex items-center gap-1 px-2 py-1.5 rounded-lg text-[12px] text-[var(--canvas-text-2)] hover:text-[var(--canvas-text-1)] hover:bg-[var(--canvas-controls-hover)] transition-colors"


### PR DESCRIPTION
Fixes #8

## 问题回顾

部分视图（**产物库、项目列表、工坊首页**）点击侧边栏收起按钮后，界面上没有任何重新展开的入口；且 `sidebarCollapsed` 会被持久化，重启后仍是收起状态。

根因：收起按钮在 `Sidebar.tsx` 内部，收起后整个 Sidebar 卸载；「展开把手」此前由各视图**各自实现**，没实现的视图就是死路——这是逐视图 opt-in 结构性问题，单独给三个视图补按钮后，未来新增视图仍会漏。

## 方案

把展开把手**上收到 App 层**，所有视图共享一份，子视图零感知：

- 新增 `src/components/SidebarHandle.tsx`，挂载于所有视图共同的父级（`App.tsx` 把视图切换区包了一层），侧栏收起时在**左上角**渲染唯一的展开按钮
- 图标与配色按视图查 `VIEW_SKINS` 注册表，**沿用各视图原把手的图标与底色**：
  - chat / 微信 / 飞书 = `Menu` 幽灵钮（透明底透出页面底色）
  - 画布 = 原方形分割线 SVG + `--canvas-panel` 面板小方片（恰为其顶栏底色）
  - 工坊 / 剪辑 / 文案 / 产物库 / 项目 = `PanelLeftOpen`（画布系面板片，浅色视图 stone 系同页面底色）
  - 未登记视图走默认图标，优雅降级；主题 CSS 变量定义在 `.canvas-dark` / `.copywriting-light` 类本身，把手自带主题类即可解析
- **失败模式从「死路」变为「默认图标」**：新增视图忘了登记注册表，功能依然完好

配套清理：

| 改动 | 说明 |
| --- | --- |
| 删除 7 处视图内重复把手 | chat / 画布 / 微信 / 飞书 / 文案 / 工坊×2（含孤儿 import 与 store 订阅） |
| 工坊 TopBar、EditorTopBar 双态按钮 → 仅收起 | 收起时隐藏避免与全局把手重复；留等宽占位，标题不位移 |
| 微信 / 飞书 | 保留原把手条等高占位，内容不上移 |
| 产物库 / 项目标题 | 收起时行加条件 `pl-5` 让位（padding 不参与 `justify-between` 分配，标题不居中、不换行） |

## 验证

- 基于 `9336fc9`（upstream/main）干净分支：`tsc --noEmit` ✅、`vite build` ✅
- 逐视图实测收起→展开：9 个视图左上角均有把手，点击展开正常；产物库 / 项目列表 / 工坊首页死路修复
- `sidebarCollapsed` 持久化（重启后仍收起）时走同一渲染路径，把手同样出现