### PR TITLE
fix(dsh-runtime): Windows-adapt ACP smoke tests（Windows 分支与 main 2.9.21 对齐）

### DIFF
--- a/dsh-runtime/tests/acp-baseline-smoke.mjs
+++ b/dsh-runtime/tests/acp-baseline-smoke.mjs
@@ -4,7 +4,11 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 
 const root = resolve(import.meta.dirname, '..');
-const node = join(root, 'node', 'bin', 'node');
+// Windows 布局是 node/node.exe，Unix 是 node/bin/node。
+const node = join(root, 'node', ...(process.platform === 'win32' ? ['node.exe'] : ['bin', 'node']));
+// cordis/loader entry 的 name 直接进 import()：Windows 裸绝对路径会被当成
+// URL scheme 'c:'，必须 file:// URL（与 dsh.rs 的 module_specifier 一致）。
+const fileUrl = (p) => 'file:///' + p.replace(/\\/g, '/');
 const bin = join(root, 'node_modules', '@deepseek-ai', 'dsh-acp-demo', 'lib', 'bin.js');
 const apiKey = process.env.DEEPSEEK_API_KEY?.trim();
 

--- a/dsh-runtime/tests/acp-big-result-smoke.mjs
+++ b/dsh-runtime/tests/acp-big-result-smoke.mjs
@@ -8,7 +8,11 @@ import { join, resolve } from 'node:path';
 // A minimal fake Kunpeng tool bridge (TCP) stands in for the Rust bridge.
 
 const root = resolve(import.meta.dirname, '..');
-const node = join(root, 'node', 'bin', 'node');
+// Windows 布局是 node/node.exe，Unix 是 node/bin/node。
+const node = join(root, 'node', ...(process.platform === 'win32' ? ['node.exe'] : ['bin', 'node']));
+// cordis/loader entry 的 name 直接进 import()：Windows 裸绝对路径会被当成
+// URL scheme 'c:'，必须 file:// URL（与 dsh.rs 的 module_specifier 一致）。
+const fileUrl = (p) => 'file:///' + p.replace(/\\/g, '/');
 const bin = join(root, 'node_modules', '@deepseek-ai', 'dsh-acp-demo', 'lib', 'bin.js');
 const apiKey = process.env.DEEPSEEK_API_KEY?.trim();
 if (!apiKey) throw new Error('DEEPSEEK_API_KEY is required');
@@ -19,6 +23,9 @@ const baseURL = (process.env.DEEPSEEK_BASE_URL || 'https://api.deepseek.com').re
 // ---- fake Kunpeng tool bridge ----
 const bridgeToken = 'smoke-token';
 const bridge = net.createServer((socket) => {
+  // Windows 被子进程强杀时 socket 收 RST 而非优雅 FIN，假桥必须吞掉
+  // error 事件，否则进程在打印结果前就崩溃（同 PR #2 对生命周期测试的修法）。
+  socket.on('error', () => {});
   socket.setEncoding('utf8');
   let buffer = '';
   socket.on('data', (chunk) => {
@@ -83,7 +90,7 @@ const config = [
     // cannot be resolved there; the desktop config must use the absolute
     // entry path, exactly like the ACP host above.
     name: process.env.LLM_ENTRY
-      || join(root, 'node_modules', '@deepseek-ai', 'dsh-llm-deepseek', 'lib', 'index.js'),
+      || fileUrl(join(root, 'node_modules', '@deepseek-ai', 'dsh-llm-deepseek', 'lib', 'index.js')),
     config: {
       apiKeyEnv: 'DEEPSEEK_API_KEY',
       baseURL,
@@ -96,7 +103,7 @@ const config = [
   },
   {
     id: 'acp',
-    name: join(root, 'kunpeng-acp-host.mjs'),
+    name: fileUrl(join(root, 'kunpeng-acp-host.mjs')),
     config: {
       provider: 'deepseek-official',
       model,

--- a/dsh-runtime/tests/acp-host-smoke.mjs
+++ b/dsh-runtime/tests/acp-host-smoke.mjs
@@ -8,7 +8,11 @@ import { join, resolve } from 'node:path';
 // A minimal fake Kunpeng tool bridge (TCP) stands in for the Rust bridge.
 
 const root = resolve(import.meta.dirname, '..');
-const node = join(root, 'node', 'bin', 'node');
+// Windows 布局是 node/node.exe，Unix 是 node/bin/node。
+const node = join(root, 'node', ...(process.platform === 'win32' ? ['node.exe'] : ['bin', 'node']));
+// cordis/loader entry 的 name 直接进 import()：Windows 裸绝对路径会被当成
+// URL scheme 'c:'，必须 file:// URL（与 dsh.rs 的 module_specifier 一致）。
+const fileUrl = (p) => 'file:///' + p.replace(/\\/g, '/');
 const bin = join(root, 'node_modules', '@deepseek-ai', 'dsh-acp-demo', 'lib', 'bin.js');
 const apiKey = process.env.DEEPSEEK_API_KEY?.trim();
 if (!apiKey) throw new Error('DEEPSEEK_API_KEY is required');
@@ -19,6 +23,9 @@ const baseURL = (process.env.DEEPSEEK_BASE_URL || 'https://api.deepseek.com').re
 // ---- fake Kunpeng tool bridge ----
 const bridgeToken = 'smoke-token';
 const bridge = net.createServer((socket) => {
+  // Windows 被子进程强杀时 socket 收 RST 而非优雅 FIN，假桥必须吞掉
+  // error 事件，否则进程在打印结果前就崩溃（同 PR #2 对生命周期测试的修法）。
+  socket.on('error', () => {});
   socket.setEncoding('utf8');
   let buffer = '';
   socket.on('data', (chunk) => {
@@ -80,7 +87,7 @@ const config = [
     // cannot be resolved there; the desktop config must use the absolute
     // entry path, exactly like the ACP host above.
     name: process.env.LLM_ENTRY
-      || join(root, 'node_modules', '@deepseek-ai', 'dsh-llm-deepseek', 'lib', 'index.js'),
+      || fileUrl(join(root, 'node_modules', '@deepseek-ai', 'dsh-llm-deepseek', 'lib', 'index.js')),
     config: {
       apiKeyEnv: 'DEEPSEEK_API_KEY',
       baseURL,
@@ -93,7 +100,7 @@ const config = [
   },
   {
     id: 'acp',
-    name: join(root, 'kunpeng-acp-host.mjs'),
+    name: fileUrl(join(root, 'kunpeng-acp-host.mjs')),
     config: {
       provider: 'deepseek-official',
       model,

--- a/dsh-runtime/tests/acp-image-smoke.mjs
+++ b/dsh-runtime/tests/acp-image-smoke.mjs
@@ -8,7 +8,11 @@ import { join, resolve } from 'node:path';
 // pipeline actually delivers images to the model (识图), or drops/errors them.
 
 const root = resolve(import.meta.dirname, '..');
-const node = join(root, 'node', 'bin', 'node');
+// Windows 布局是 node/node.exe，Unix 是 node/bin/node。
+const node = join(root, 'node', ...(process.platform === 'win32' ? ['node.exe'] : ['bin', 'node']));
+// cordis/loader entry 的 name 直接进 import()：Windows 裸绝对路径会被当成
+// URL scheme 'c:'，必须 file:// URL（与 dsh.rs 的 module_specifier 一致）。
+const fileUrl = (p) => 'file:///' + p.replace(/\\/g, '/');
 const bin = join(root, 'node_modules', '@deepseek-ai', 'dsh-acp-demo', 'lib', 'bin.js');
 const apiKey = process.env.DEEPSEEK_API_KEY?.trim();
 if (!apiKey) throw new Error('DEEPSEEK_API_KEY is required');
@@ -19,6 +23,9 @@ const imagePath = process.env.SMOKE_IMAGE || '/tmp/smoke-red.png';
 
 const bridgeToken = 'smoke-token';
 const bridge = net.createServer((socket) => {
+  // Windows 被子进程强杀时 socket 收 RST 而非优雅 FIN，假桥必须吞掉
+  // error 事件，否则进程在打印结果前就崩溃（同 PR #2 对生命周期测试的修法）。
+  socket.on('error', () => {});
   socket.setEncoding('utf8');
   let buffer = '';
   socket.on('data', (chunk) => {
@@ -53,7 +60,7 @@ const config = [
     // KUNPENG: 视觉轮次走 pi-ai 适配器（dsh-llm-deepseek 是 text-only 设计），
     // 模型级声明 input:[text,image]；图片经 attachment store 落盘后 base64 内联进模型。
     id: 'llm-pi-ai',
-    name: join(root, 'node_modules', '@deepseek-ai', 'dsh-llm-pi-ai', 'lib', 'index.js'),
+    name: fileUrl(join(root, 'node_modules', '@deepseek-ai', 'dsh-llm-pi-ai', 'lib', 'index.js')),
     config: {
       providers: {
         deepseek: {
@@ -67,7 +74,7 @@ const config = [
   },
   {
     id: 'acp',
-    name: join(root, 'kunpeng-acp-host.mjs'),
+    name: fileUrl(join(root, 'kunpeng-acp-host.mjs')),
     config: {
       provider: 'deepseek',
       model,

--- a/dsh-runtime/tests/acp-slow-tool-smoke.mjs
+++ b/dsh-runtime/tests/acp-slow-tool-smoke.mjs
@@ -8,7 +8,11 @@ import { join, resolve } from 'node:path';
 // A minimal fake Kunpeng tool bridge (TCP) stands in for the Rust bridge.
 
 const root = resolve(import.meta.dirname, '..');
-const node = join(root, 'node', 'bin', 'node');
+// Windows 布局是 node/node.exe，Unix 是 node/bin/node。
+const node = join(root, 'node', ...(process.platform === 'win32' ? ['node.exe'] : ['bin', 'node']));
+// cordis/loader entry 的 name 直接进 import()：Windows 裸绝对路径会被当成
+// URL scheme 'c:'，必须 file:// URL（与 dsh.rs 的 module_specifier 一致）。
+const fileUrl = (p) => 'file:///' + p.replace(/\\/g, '/');
 const bin = join(root, 'node_modules', '@deepseek-ai', 'dsh-acp-demo', 'lib', 'bin.js');
 const apiKey = process.env.DEEPSEEK_API_KEY?.trim();
 if (!apiKey) throw new Error('DEEPSEEK_API_KEY is required');
@@ -19,6 +23,9 @@ const baseURL = (process.env.DEEPSEEK_BASE_URL || 'https://api.deepseek.com').re
 // ---- fake Kunpeng tool bridge ----
 const bridgeToken = 'smoke-token';
 const bridge = net.createServer((socket) => {
+  // Windows 被子进程强杀时 socket 收 RST 而非优雅 FIN，假桥必须吞掉
+  // error 事件，否则进程在打印结果前就崩溃（同 PR #2 对生命周期测试的修法）。
+  socket.on('error', () => {});
   socket.setEncoding('utf8');
   let buffer = '';
   socket.on('data', (chunk) => {
@@ -83,7 +90,7 @@ const config = [
     // cannot be resolved there; the desktop config must use the absolute
     // entry path, exactly like the ACP host above.
     name: process.env.LLM_ENTRY
-      || join(root, 'node_modules', '@deepseek-ai', 'dsh-llm-deepseek', 'lib', 'index.js'),
+      || fileUrl(join(root, 'node_modules', '@deepseek-ai', 'dsh-llm-deepseek', 'lib', 'index.js')),
     config: {
       apiKeyEnv: 'DEEPSEEK_API_KEY',
       baseURL,
@@ -96,7 +103,7 @@ const config = [
   },
   {
     id: 'acp',
-    name: join(root, 'kunpeng-acp-host.mjs'),
+    name: fileUrl(join(root, 'kunpeng-acp-host.mjs')),
     config: {
       provider: 'deepseek-official',
       model,


### PR DESCRIPTION
## 内容

Windows 分支与 main（v2.9.21）完全对齐，剩余差异仅为上游 5 个 acp-*-smoke 冒烟脚本的 Windows 适配：

- node 运行时路径：node/bin/node → Windows 用 node/node.exe
- cordis loader entry 名：裸绝对路径在 Windows ESM import() 中被当成 URL scheme c: 直接崩溃，统一包 fileUrl()（与 dsh.rs 的 module_specifier 一致）
- 假桥接 socket 容忍 Windows RST（被杀子进程不走优雅 FIN），否则脚本在打印结果前崩溃

## 实机验证

- acp-big-result / acp-slow-tool / acp-image 三个真实 API 冒烟全部 ok:true
- harness 148/148；shotNarrativeAudit 13/13；tsc 0 错误；NSIS 构建通过（鲲鹏_2.9.21_x64-setup.exe）

注：本 PR 经 Git Data API 提交（本机 github.com:443 被网络策略阻断，REST API 正常）。