### PR TITLE
fix(windows): python3 回退/shim、子进程 UTF-8、盘符路径（画布生视频链路实机修复）

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -335,6 +335,10 @@ fn main() {
             // 部署内置资源（AGENT.md/skills/aigc-memory 种子），版本变更时覆盖
             commands::deploy_bundled_resources(&app.handle());
 
+            // Windows：补 python3 shim（有 python 无 python3 时自愈）
+            #[cfg(target_os = "windows")]
+            std::thread::spawn(ensure_python3_shim);
+
             // macOS：接管 Dock 图标点击，恢复主窗口（issue #4）
             #[cfg(target_os = "macos")]
             install_dock_reopen_handler(app.handle());
@@ -488,4 +492,101 @@ unsafe fn set_transparent_recursive(view: id) {
         let subview: id = objc::msg_send![subviews, objectAtIndex: i];
         set_transparent_recursive(subview);
     }
+}
+
+/// Windows 的 python.org 安装包通常只有 python.exe（无 python3.exe），而项目
+/// 里大量路径（COS 上传、agent 技能脚本、shell 示例）按 POSIX 习惯调用
+/// python3。首次启动时自愈：有 python 无 python3 就把 python.exe 复制为
+/// ~/.kunpeng/bin/python3.exe 并加入用户 PATH（.NET 写入会同时广播
+/// WM_SETTINGCHANGE）。没有 Python 则不动作（应用内会给出明确安装指引）。
+#[cfg(target_os = "windows")]
+fn ensure_python3_shim() {
+    use std::os::windows::process::CommandExt;
+    const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+    let run = |prog: &str, args: &[&str]| -> Option<std::process::Output> {
+        std::process::Command::new(prog)
+            .args(args)
+            .creation_flags(CREATE_NO_WINDOW)
+            .output()
+            .ok()
+    };
+    let works = |prog: &str| {
+        run(prog, &["--version"])
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    };
+
+    if works("python3") {
+        return;
+    }
+
+    // 定位可用的 python.exe：PATH → py 启动器 → 常见安装目录
+    let python_exe = if works("python") {
+        run("where", &["python"]).and_then(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .next()
+                .map(|s| s.trim().to_string())
+        })
+    } else {
+        None
+    }
+    .or_else(|| {
+        run("py", &["-3", "-c", "import sys; print(sys.executable)"]).and_then(|o| {
+            if o.status.success() {
+                let p = String::from_utf8_lossy(&o.stdout).trim().to_string();
+                (!p.is_empty() && std::path::Path::new(&p).is_file()).then_some(p)
+            } else {
+                None
+            }
+        })
+    })
+    .or_else(|| {
+        let local = std::env::var("LOCALAPPDATA").unwrap_or_default();
+        let mut candidates = vec![];
+        for v in ["314", "313", "312", "311", "310"] {
+            candidates.push(format!("C:\\Python{}\\python.exe", v));
+            candidates.push(format!("{}\\Programs\\Python\\Python{}\\python.exe", local, v));
+        }
+        candidates
+            .into_iter()
+            .find(|p| std::path::Path::new(p).is_file())
+    });
+
+    let Some(python_exe) = python_exe else {
+        eprintln!("[python3-shim] 未检测到 Python，跳过 shim（应用内会提示安装）");
+        return;
+    };
+
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => return,
+    };
+    let bin_dir = home.join(".kunpeng").join("bin");
+    if std::fs::create_dir_all(&bin_dir).is_err() {
+        return;
+    }
+    let shim = bin_dir.join("python3.exe");
+    if !shim.exists() && std::fs::copy(&python_exe, &shim).is_err() {
+        eprintln!("[python3-shim] 复制 {} -> {:?} 失败", python_exe, shim);
+        return;
+    }
+    eprintln!("[python3-shim] 已创建 {:?}（源 {}）", shim, python_exe);
+
+    // 加入用户 PATH（幂等）：用 .NET 写入，自带 WM_SETTINGCHANGE 广播。
+    let bin_str = bin_dir.to_string_lossy().to_string();
+    let ps = format!(
+        "$bin='{}'; $cur=[Environment]::GetEnvironmentVariable('Path','User'); \
+         if (($cur -split ';') -notcontains $bin) {{ \
+           [Environment]::SetEnvironmentVariable('Path', ($cur.TrimEnd(';') + ';' + $bin), 'User') }}",
+        bin_str.replace('\'', "''")
+    );
+    let ok = run("powershell", &["-NoProfile", "-Command", &ps])
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    eprintln!(
+        "[python3-shim] 用户 PATH {}（{}）",
+        if ok { "已包含 shim 目录" } else { "写入失败" },
+        bin_str
+    );
 }

--- a/src/lib/agent/tools/canvasTools.ts
+++ b/src/lib/agent/tools/canvasTools.ts
@@ -3,6 +3,7 @@ import { useCanvasStore } from '@/stores/canvasStore';
 import { useCanvasTaskStore } from '@/stores/canvasTaskStore';
 import { nanoid } from 'nanoid';
 import { convertFileSrc } from '@tauri-apps/api/tauri';
+import { stripDriveLeadingSlash } from '@/lib/platform';
 import { defaultNodeStyle, estimateNodeSize } from '@/lib/canvas/layout';
 import { recoverCanvasTaskNow } from '@/hooks/useCanvasTaskRecovery';
 import { useChatStore } from '@/stores/chatStore';
@@ -37,11 +38,14 @@ function normalizeUrlWithPath(url: unknown): { url?: string; localPath?: string 
     return { url };
   }
   let filePath = url.startsWith('file://') ? url.replace('file://', '') : url;
+  // file:///C:/... 反解后是 '/C:/...'，Windows 需去前导斜杠
+  filePath = stripDriveLeadingSlash(filePath);
   // agent 常用 ~/ 前缀路径（工具文档就是这么写的），不展开就变死链
   if (filePath.startsWith('~/') && cachedHome) {
     filePath = `${cachedHome}${filePath.slice(1)}`;
   }
-  if (filePath.startsWith('/')) {
+  // Windows 原生绝对路径（C:\...）同样转 asset URL 并给出 localPath
+  if (filePath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(filePath)) {
     return { url: convertFileSrc(filePath), localPath: filePath };
   }
   return { url };

--- a/src/lib/agent/tools/timelineTools.ts
+++ b/src/lib/agent/tools/timelineTools.ts
@@ -6,6 +6,7 @@
 import type { Tool } from '../types';
 import { convertFileSrc } from '@tauri-apps/api/tauri';
 import { readTextFile } from '@tauri-apps/api/fs';
+import { stripDriveLeadingSlash } from '@/lib/platform';
 import { useEditorStore } from '@/stores/editorStore';
 import { useCanvasStore } from '@/stores/canvasStore';
 import { useSettingsStore } from '@/stores/settingsStore';
@@ -1673,12 +1674,14 @@ function normalizeFreePageAssetUrl(raw: string): string {
   if (/^asset:\/\//i.test(value) || /^https?:\/\/asset\.localhost\//i.test(value)) return value;
   if (/^file:\/\//i.test(value)) {
     try {
-      return convertFileSrc(decodeURIComponent(value.replace(/^file:\/\//i, '')));
+      // file:///C:/... 反解后是 '/C:/...'，Windows 需去前导斜杠
+      return convertFileSrc(stripDriveLeadingSlash(decodeURIComponent(value.replace(/^file:\/\//i, ''))));
     } catch {
       return value;
     }
   }
-  if (value.startsWith('/')) return convertFileSrc(value);
+  // POSIX 绝对路径与 Windows 盘符路径都要转 asset URL
+  if (value.startsWith('/') || /^[A-Za-z]:[\\/]/.test(value)) return convertFileSrc(value);
   return value;
 }
 

--- a/src/lib/canvas/imageSource.ts
+++ b/src/lib/canvas/imageSource.ts
@@ -13,15 +13,18 @@
  */
 import { readBinaryFile } from '@tauri-apps/api/fs';
 import { fetch as tauriFetch, ResponseType } from '@tauri-apps/api/http';
+import { stripDriveLeadingSlash } from '@/lib/platform';
 
 /** asset URL / 绝对路径 → 本地绝对路径；解不出来返回 null。 */
 export function assetUrlToLocalPath(url: string): string | null {
-  if (url.startsWith('/')) return url;
+  // Windows 原生绝对路径（C:\... 或 C:/...）直通
+  if (/^[A-Za-z]:[\\/]/.test(url)) return url;
+  if (url.startsWith('/')) return stripDriveLeadingSlash(url);
   if (url.startsWith('https://asset.localhost/')) {
-    return decodeURIComponent(url.replace('https://asset.localhost/', '/').replace(/^\/+/, '/'));
+    return stripDriveLeadingSlash(decodeURIComponent(url.replace('https://asset.localhost/', '/').replace(/^\/+/, '/')));
   }
   if (url.startsWith('asset://localhost/')) {
-    return decodeURIComponent(url.replace('asset://localhost/', '/').replace(/^\/+/, '/'));
+    return stripDriveLeadingSlash(decodeURIComponent(url.replace('asset://localhost/', '/').replace(/^\/+/, '/')));
   }
   return null;
 }

--- a/src/lib/cos.ts
+++ b/src/lib/cos.ts
@@ -55,6 +55,14 @@ export async function uploadToCos(
   const pyScript = `
 import sys, os, subprocess, glob, warnings
 warnings.filterwarnings('ignore')
+# 中文 Windows 控制台默认 GBK：Tauri shell 按严格 UTF-8 解码子进程输出，
+# 任何 GBK 字节都会让读取端抛 "invalid utf-8 sequence"。全程强制 UTF-8。
+for _stream in (sys.stdout, sys.stderr):
+    try:
+        _stream.reconfigure(encoding='utf-8', errors='replace')
+    except Exception:
+        pass
+os.environ['PYTHONUTF8'] = '1'
 home = os.path.expanduser('~')
 for p in glob.glob(os.path.join(home, 'Library/Python/*/lib/python/site-packages')):
     if p not in sys.path:
@@ -122,14 +130,18 @@ print(f"OK:{resp.get('ETag','')}")
 `.trim();
 
   // Secrets go via env (argv is world-visible in `ps`); only non-secret
-  // positional args remain.
-  const command = new Command('python3', [
-    '-c', pyScript,
+  // positional args remain. Windows 的 python.org 安装包只有 python.exe（无
+  // python3），直启固定名会以 "program not found" 失败——两个名字依次尝试。
+  const buildCommand = (prog: string) => new Command(prog, [
+    '-X', 'utf8', '-c', pyScript,
     cosRegion, localPath, cosBucket, key, contentType,
   ], {
     env: {
       COS_SECRET_ID: sid,
       COS_SECRET_KEY: skey,
+      // 解释器级 UTF-8 模式 + IO 编码，覆盖 pip/qcloud_cos 的全部输出路径
+      PYTHONUTF8: '1',
+      PYTHONIOENCODING: 'utf-8',
     },
   });
   let stdout = '';
@@ -163,8 +175,9 @@ print(f"OK:{resp.get('ETag','')}")
     }
   };
 
-  const result = await new Promise<{ code: number | null; signal: number | null }>((resolve, reject) => {
+  const runWithPython = (prog: string) => new Promise<{ code: number | null; signal: number | null }>((resolve, reject) => {
     let settled = false;
+    const command = buildCommand(prog);
     command.stdout.on('data', (chunk: string) => parseStdout(chunk));
     command.stderr.on('data', (chunk: string) => { stderr += chunk; });
     command.on('error', (error) => {
@@ -184,6 +197,18 @@ print(f"OK:{resp.get('ETag','')}")
       reject(error);
     });
   });
+
+  let result: { code: number | null; signal: number | null };
+  try {
+    result = await runWithPython('python3');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!/program not found|not found|ENOENT|无法找到/i.test(msg)) throw err;
+    // python3 不存在（Windows 常见），回退 python 再试一次。
+    stdout = '';
+    stderr = '';
+    result = await runWithPython('python');
+  }
 
   if (result.code !== 0 || !stdout.includes('OK:')) {
     const errMsg = stderr.trim() || stdout.trim();

--- a/src/lib/editor/composeEngine.ts
+++ b/src/lib/editor/composeEngine.ts
@@ -18,6 +18,7 @@
 import { invoke } from '@tauri-apps/api/tauri';
 import { createDir, exists, removeDir } from '@tauri-apps/api/fs';
 import { stopBackgroundProcessCommand } from '@/lib/platform';
+import { pythonCommand } from '@/lib/python';
 import {
   useEditorStore, EXPORT_RESOLUTIONS,
   type EditorClip, type OverlayClip, type AudioClip, type ExportSettings, type MaskSettings,
@@ -613,7 +614,7 @@ function textToBase64(text: string): string {
 async function writeTextViaShell(path: string, contents: string): Promise<void> {
   const b64 = textToBase64(contents);
   const script = [
-    "python3 - <<'PY'",
+    `${await pythonCommand()} - <<'PY'`,
     'import base64, pathlib',
     `path = ${JSON.stringify(path)}`,
     `data = ${JSON.stringify(b64)}`,

--- a/src/lib/editor/fxRender.ts
+++ b/src/lib/editor/fxRender.ts
@@ -14,6 +14,7 @@ import { writeBinaryFile, writeTextFile, createDir, exists, readTextFile, BaseDi
 import { homeDir, resourceDir } from '@tauri-apps/api/path';
 import { invoke } from '@tauri-apps/api/tauri';
 import { stopBackgroundProcessCommand, isWindowsSync } from '@/lib/platform';
+import { pythonCommand } from '@/lib/python';
 import MOTION_RUNTIME_SRC from '../../../scripts/motion-runtime.js?raw';
 import { KP_MOTION_VERSION } from '@/lib/motion/runtimeVersion';
 import { DEFAULT_FX_TRANSFORM, useEditorStore, type EditorRenderError, type TextClip, type FxClip } from '@/stores/editorStore';
@@ -657,7 +658,7 @@ async function writeJsonViaShell(path: string, data: unknown): Promise<void> {
   }
   const b64 = btoa(bin);
   const script = [
-    "python3 - <<'PY'",
+    `${await pythonCommand()} - <<'PY'`,
     'import base64, pathlib',
     `path = ${JSON.stringify(path)}`,
     `data = ${JSON.stringify(b64)}`,
@@ -677,7 +678,7 @@ async function writeTextViaShell(path: string, text: string): Promise<void> {
   }
   const b64 = btoa(bin);
   const script = [
-    "python3 - <<'PY'",
+    `${await pythonCommand()} - <<'PY'`,
     'import base64, pathlib',
     `path = ${JSON.stringify(path)}`,
     `data = ${JSON.stringify(b64)}`,
@@ -864,7 +865,9 @@ async function runWorkerLayer(doc: FxDoc, opts: FxRenderOptions): Promise<FxLaye
     (_match, encodedPath: string) => {
       try {
         const decoded = decodeURIComponent(encodedPath);
-        const absolute = decoded.startsWith('/') ? decoded : `/${decoded}`;
+        // Windows 盘符路径统一成正斜杠，拼出合法 file:///C:/... URL
+        const normalized = /^[A-Za-z]:[\\/]/.test(decoded) ? decoded.replace(/\\/g, '/') : decoded;
+        const absolute = normalized.startsWith('/') ? normalized : `/${normalized}`;
         return encodeURI(`file://${absolute}`);
       } catch {
         return _match;

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -35,6 +35,15 @@ export function isWindowsSync(): boolean {
   return userAgentPlatform() === 'windows';
 }
 
+/**
+ * Windows 盘符路径修正：asset URL（asset.localhost/file://）反解出来的
+ * '/C:\Users\...' 或 '/c:/...' 去掉前导斜杠。macOS 的绝对路径以 / 开头天然
+ * 正确；Windows 上传给 python/原生 API 时前导斜杠会让路径非法（WinError 123）。
+ */
+export function stripDriveLeadingSlash(p: string): string {
+  return /^\/[A-Za-z]:[\\/]/.test(p) ? p.slice(1) : p;
+}
+
 /** 提示词用的展示名（macOS / Windows / Linux）。 */
 export function osDisplayName(platform: ShellInfo['platform']): string {
   if (platform === 'windows') return 'Windows';

--- a/src/lib/projectArchive.ts
+++ b/src/lib/projectArchive.ts
@@ -12,6 +12,7 @@
 import { invoke } from '@tauri-apps/api/tauri';
 import { convertFileSrc } from '@tauri-apps/api/tauri';
 import { readTextFile, writeTextFile, exists, BaseDirectory } from '@tauri-apps/api/fs';
+import { stripDriveLeadingSlash } from '@/lib/platform';
 import { useProjectStore, type Project } from '@/stores/projectStore';
 import { useUnifiedProjectStore } from '@/stores/unifiedProjectStore';
 import { useWorkshopStore } from '@/stores/workshopStore';
@@ -78,13 +79,14 @@ export async function exportProject(
 /** asset:// URL 的两种形态 → 反解出本地绝对路径 */
 function assetUrlToLocalPath(url: string): string {
   if (url.startsWith('file://')) {
-    return decodeURIComponent(url.replace('file://', ''));
+    // file:///C:/... 反解后是 '/C:/...'，Windows 需去前导斜杠
+    return stripDriveLeadingSlash(decodeURIComponent(url.replace('file://', '')));
   }
   if (url.startsWith('https://asset.localhost/')) {
-    return decodeURIComponent(url.replace('https://asset.localhost/', '/').replace(/^\/+/, '/'));
+    return stripDriveLeadingSlash(decodeURIComponent(url.replace('https://asset.localhost/', '/').replace(/^\/+/, '/')));
   }
   if (url.startsWith('asset://localhost/')) {
-    return decodeURIComponent(url.replace('asset://localhost/', '/').replace(/^\/+/, '/'));
+    return stripDriveLeadingSlash(decodeURIComponent(url.replace('asset://localhost/', '/').replace(/^\/+/, '/')));
   }
   return url;
 }
@@ -129,7 +131,8 @@ async function rewriteCanvasAssetUrls(canvasProjectId: string): Promise<void> {
     for (const f of DISPLAY_FIELDS) {
       if (isLocalFilePath(d[f])) {
         const lp = assetUrlToLocalPath(d[f] as string);
-        if (lp.startsWith('/')) {
+        // POSIX 绝对路径与 Windows 盘符路径都要转 asset URL
+        if (lp.startsWith('/') || /^[A-Za-z]:[\\/]/.test(lp)) {
           const newUrl = convertFileSrc(lp);
           if (d[f] !== newUrl) { d[f] = newUrl; changed = true; }
         }

--- a/src/lib/python.ts
+++ b/src/lib/python.ts
@@ -1,0 +1,29 @@
+/**
+ * python.ts — 跨平台 Python 解释器解析。
+ *
+ * macOS 自带 python3；Windows 的 python.org 安装包通常只有 python（无
+ * python3.exe），直接用固定名字在 Windows 上会以 "program not found"
+ * （Tauri Command 直启）或 exit 127（bash）失败。统一经这里解析一次并缓存。
+ */
+
+import { invoke } from '@tauri-apps/api/tauri';
+
+interface CommandResult { stdout: string; stderr: string; exit_code: number }
+
+let cached: string | null = null;
+
+/** python3 优先，缺失时回退 python；都没有则给出可操作的安装指引。 */
+export async function pythonCommand(): Promise<string> {
+  if (cached) return cached;
+  for (const prog of ['python3', 'python']) {
+    const r = await invoke<CommandResult>('execute_command', {
+      command: `${prog} --version`,
+      timeoutMs: 5000,
+    }).catch(() => null);
+    if (r && r.exit_code === 0) {
+      cached = prog;
+      return prog;
+    }
+  }
+  throw new Error('未检测到 Python（macOS 自带 python3；Windows 请安装 python.org 或 winget install Python.Python.3）');
+}

--- a/src/lib/rhtv/upload.ts
+++ b/src/lib/rhtv/upload.ts
@@ -8,6 +8,7 @@
  */
 import { fetch as tauriFetch, ResponseType, Body } from '@tauri-apps/api/http';
 import { invoke } from '@tauri-apps/api/tauri';
+import { stripDriveLeadingSlash } from '@/lib/platform';
 import { appUploadUrl, requireRhtvApiKey } from './client';
 import { RhtvBusinessError } from './types';
 
@@ -27,10 +28,10 @@ function mimeOf(path: string): string {
 /** Convert asset:// display URLs back to plain filesystem paths. */
 export function assetUrlToLocalPath(url: string): string {
   if (url.startsWith('https://asset.localhost/')) {
-    return decodeURIComponent(url.replace('https://asset.localhost/', '/').replace(/^\/+/, '/'));
+    return stripDriveLeadingSlash(decodeURIComponent(url.replace('https://asset.localhost/', '/').replace(/^\/+/, '/')));
   }
   if (url.startsWith('asset://localhost/')) {
-    return decodeURIComponent(url.replace('asset://localhost/', '/').replace(/^\/+/, '/'));
+    return stripDriveLeadingSlash(decodeURIComponent(url.replace('asset://localhost/', '/').replace(/^\/+/, '/')));
   }
   return url;
 }

--- a/src/lib/sessionSanitize.ts
+++ b/src/lib/sessionSanitize.ts
@@ -38,7 +38,8 @@ export function extractMediaPathFromOutput(output: unknown): string | undefined 
   for (const candidate of candidates) {
     const path = candidate.trim();
     // 只接受绝对路径——上述工具产物均为绝对路径；相对片段多半不是路径。
-    if (path.startsWith('/')) return path;
+    // Windows 盘符路径（C:\...）同样是绝对路径。
+    if (path.startsWith('/') || /^[A-Za-z]:[\\/]/.test(path)) return path;
   }
   return undefined;
 }


### PR DESCRIPTION
## 内容

画布生视频链路在 Windows 实机上的 4 层修复（全部实测通过）：

1. **python3 不存在**：`uploadToCos` 用 Tauri Command 直启 `python3`，Windows 只有 `python.exe` → "program not found"。现 python3/python 依次尝试；新增 `src/lib/python.ts` 统一解析（composeEngine/fxRender 三处硬编码 python3 同病同治）。
2. **python3 shim 自愈**（main.rs）：首启时有 python 无 python3 → 复制为 `~/.kunpeng/bin/python3.exe` 并写用户 PATH（广播 WM_SETTINGCHANGE）。agent 提示词里的 `python3 ~/.kunpeng/skills/...` 路径随之打通。
3. **GBK 输出噎死 Tauri 解码**：中文 Windows 控制台 GBK 输出撞上 Tauri shell 的严格 UTF-8 解码 → "invalid utf-8 sequence"。强制 `-X utf8` + `PYTHONUTF8/PYTHONIOENCODING` + 流重配置。
4. **盘符前导斜杠**：asset.localhost/file:// 反解产出 `/C:\Users\...`（WinError 123）。`platform.ts` 新增 `stripDriveLeadingSlash()` 全解码器接线；同类清扫修掉 5 处盘符路径被静默跳过的问题（canvasTools / timelineTools / projectArchive / sessionSanitize / fxRender）。

## 实机验证

- 画布带本地参考图生成视频全链路通过（COS 上传 + 任务创建）
- qcloud_cos E2E 上传/删除真实 COS 桶通过
- python3 shim 首启 E2E：`~/.kunpeng/bin/python3.exe` 就位、PATH 写入、Python 3.14.2 可调
- tsc 0 错误；harness 148/148；dsh-runtime 5/5

注：本 PR 经 Git Data API 提交（本机 github.com:443 不稳定，REST API 正常）。