### PR TITLE
feat: 支持配置自定义 S3 兼容媒体存储

### DIFF
--- a/scf/cos-transit/index.py
+++ b/scf/cos-transit/index.py
@@ -10,6 +10,7 @@ Package with cos-python-sdk-v5 + urllib3<2 in the zip.
 Environment variables:
   COS_BUCKET    — e.g. my-images-1250000000 (REQUIRED, your own bucket)
   COS_REGION    — e.g. ap-guangzhou
+  COS_OBJECT_PREFIX — object key prefix, defaults to kunpeng
   COS_SECRET_ID — AKID...
   COS_SECRET_KEY — ...
 """
@@ -21,6 +22,7 @@ from qcloud_cos import CosConfig, CosS3Client
 
 BUCKET = os.environ.get('COS_BUCKET', '')
 REGION = os.environ.get('COS_REGION', 'ap-guangzhou')
+OBJECT_PREFIX = os.environ.get('COS_OBJECT_PREFIX', 'kunpeng').strip('/')
 SECRET_ID = os.environ.get('COS_SECRET_ID', '')
 SECRET_KEY = os.environ.get('COS_SECRET_KEY', '')
 
@@ -45,7 +47,7 @@ def main_handler(event, context):
 
     config = CosConfig(Region=REGION, SecretId=SECRET_ID, SecretKey=SECRET_KEY)
     client = CosS3Client(config)
-    cos_key = f'kunpeng/transit/{file_name}'
+    cos_key = f'{OBJECT_PREFIX}/{file_name}' if OBJECT_PREFIX else file_name
     client.put_object(Bucket=BUCKET, Body=data, Key=cos_key, ContentType=content_type)
 
     cos_url = f'https://{BUCKET}.cos.{REGION}.myqcloud.com/{cos_key}'
@@ -53,5 +55,5 @@ def main_handler(event, context):
     return {
         'statusCode': 200,
         'headers': {'Content-Type': 'application/json'},
-        'body': json.dumps({'cosUrl': cos_url, 'size': len(data)})
+        'body': json.dumps({'cosUrl': cos_url, 'cosKey': cos_key, 'size': len(data)})
     }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -56,7 +56,7 @@ const SETTINGS_TABS: Array<{
   { id: 'videos', group: 'AI 服务', label: '视频与语音', description: 'Seedance、MiniMax H3、Omni MG 与豆包语音的统一管理', icon: <Film size={16} /> },
   { id: 'usage', group: 'AI 服务', label: '用量与余额', description: '查看媒体生成服务的剩余额度', icon: <Gauge size={16} /> },
   { id: 'routes', group: 'AI 服务', label: '智能路由', description: '配置模型降级链与生图通道顺序', icon: <Route size={16} /> },
-  { id: 'integrations', group: 'AI 服务', label: '存储与集成', description: 'Kimi 剪辑 Agent 与腾讯云 COS', icon: <Cloud size={16} /> },
+  { id: 'integrations', group: 'AI 服务', label: '存储与集成', description: 'Kimi 剪辑 Agent、COS 与 S3', icon: <Cloud size={16} /> },
   { id: 'data', group: '偏好设置', label: '数据与备份', description: '导入或导出鲲鹏设置', icon: <Database size={16} /> },
   { id: 'skills', group: '扩展与诊断', label: '自进化与技能', description: '查看自动反思状态、总结经验与管理技能', icon: <Boxes size={16} /> },
   { id: 'logs', group: '扩展与诊断', label: '运行日志', description: '诊断 Agent 与接口问题', icon: <ScrollText size={16} /> },
@@ -425,6 +425,8 @@ const SETTINGS_EXPORT_CREDENTIAL_KEYS = new Set([
   'webSearchCustomApiKey',
   'cosSecretId',
   'cosSecretKey',
+  's3AccessKeyId',
+  's3SecretAccessKey',
   'providerApiKeys',
   'imageApiSlots', // slots carry per-channel apiKey
   'customMediaApis', // plugins carry per-entry apiKey
@@ -480,6 +482,8 @@ function ApiKeysTab({ section }: { section: ApiSettingsSection }) {
     cosSecretId, setCosSecretId,
     cosSecretKey, setCosSecretKey,
     cosTransitEndpoint, setCosTransitEndpoint,
+    s3Endpoint, s3Region, s3Bucket, s3AccessKeyId, s3SecretAccessKey, s3Prefix, s3PublicBaseUrl, s3ForcePathStyle,
+    setS3Endpoint, setS3Region, setS3Bucket, setS3AccessKeyId, setS3SecretAccessKey, setS3Prefix, setS3PublicBaseUrl, setS3ForcePathStyle,
     webSearchApiMode, setWebSearchApiMode,
     webSearchCustomBaseUrl, setWebSearchCustomBaseUrl,
     webSearchCustomApiKey, setWebSearchCustomApiKey,
@@ -1072,6 +1076,43 @@ function ApiKeysTab({ section }: { section: ApiSettingsSection }) {
               onChange={(e) => setKimiEditUseCos(e.target.checked)}
               className="h-4 w-4 rounded border-zinc-300 text-sky-500 focus:ring-sky-200"
             />
+          </label>
+        </div>
+      </CollapsibleSection>
+
+      <CollapsibleSection title="自定义 S3 兼容存储" description="直接上传到 AWS S3、MinIO、R2 或其他 S3 兼容服务" defaultOpen={false}>
+        <div className="space-y-2">
+          <p className="text-[10px] leading-relaxed text-zinc-500">填写 Endpoint 后启用直传；留空则继续使用腾讯云 COS。</p>
+          <div>
+            <label className="block text-xs text-zinc-500 mb-1">Endpoint</label>
+            <input type="text" value={s3Endpoint} onChange={(e) => setS3Endpoint(e.target.value)} className={inputCls} placeholder="https://s3.amazonaws.com 或 https://minio.example.com" />
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="block text-xs text-zinc-500 mb-1">Region</label>
+              <input type="text" value={s3Region} onChange={(e) => setS3Region(e.target.value)} className={inputCls} placeholder="us-east-1" />
+            </div>
+            <div>
+              <label className="block text-xs text-zinc-500 mb-1">Bucket</label>
+              <input type="text" value={s3Bucket} onChange={(e) => setS3Bucket(e.target.value)} className={inputCls} placeholder="my-bucket" />
+            </div>
+          </div>
+          <div>
+            <label className="block text-xs text-zinc-500 mb-1">Access Key ID</label>
+            <input type="text" value={s3AccessKeyId} onChange={(e) => setS3AccessKeyId(e.target.value)} className={inputCls} placeholder="AKIA..." />
+          </div>
+          <KeyInputRow label="Secret Access Key" value={s3SecretAccessKey} onChange={setS3SecretAccessKey} show={showKeys.has('s3')} onToggleShow={() => toggleShow('s3')} placeholder="输入 Secret Access Key..." />
+          <div>
+            <label className="block text-xs text-zinc-500 mb-1">Object Prefix</label>
+            <input type="text" value={s3Prefix} onChange={(e) => setS3Prefix(e.target.value)} className={inputCls} placeholder="kunpeng" />
+          </div>
+          <div>
+            <label className="block text-xs text-zinc-500 mb-1">公网访问基础 URL（可选）</label>
+            <input type="text" value={s3PublicBaseUrl} onChange={(e) => setS3PublicBaseUrl(e.target.value)} className={inputCls} placeholder="https://cdn.example.com" />
+          </div>
+          <label className="flex items-center gap-2 text-xs text-zinc-600">
+            <input type="checkbox" checked={s3ForcePathStyle} onChange={(e) => setS3ForcePathStyle(e.target.checked)} className="h-4 w-4 rounded border-zinc-300 text-sky-500 focus:ring-sky-200" />
+            使用 Path-style 请求（MinIO、R2 等通常需要）
           </label>
         </div>
       </CollapsibleSection>

--- a/src/lib/cos.ts
+++ b/src/lib/cos.ts
@@ -5,6 +5,7 @@ import { Command } from '@tauri-apps/api/shell';
 import { fetch as tauriFetch, ResponseType } from '@tauri-apps/api/http';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { resolveCosSecrets } from '@/lib/credentials';
+import { uploadToS3 } from '@/lib/s3Upload';
 
 export interface CosUploadProgress {
   stage: 'preparing' | 'uploading' | 'completed';
@@ -33,6 +34,9 @@ export async function uploadToCos(
   onProgress?: (progress: CosUploadProgress) => void,
 ): Promise<string> {
   const state = useSettingsStore.getState();
+  if (state.s3Endpoint.trim()) {
+    return uploadToS3(localPath, fileName, contentTypeOverride, onProgress);
+  }
   const cosBucket = state.cosBucket;
   const cosRegion = state.cosRegion;
   const resolved = resolveCosSecrets(state, state.cosSecretId, state.cosSecretKey);

--- a/src/lib/cos.ts
+++ b/src/lib/cos.ts
@@ -241,7 +241,8 @@ export async function cosTransitDownload(remoteUrl: string, fileName: string): P
     responseType: ResponseType.JSON,
   });
   if (!resp.ok) throw new Error(`SCF 中转失败 HTTP ${resp.status}`);
-  const data = resp.data as { cosUrl?: string; error?: string };
+  const data = resp.data as { cosUrl?: string; cosKey?: string; error?: string };
   if (!data.cosUrl) throw new Error(data.error || 'SCF 未返回 cosUrl');
+  if (data.cosKey) console.info('[COS] 中转对象:', data.cosKey);
   return data.cosUrl;
 }

--- a/src/lib/s3Upload.ts
+++ b/src/lib/s3Upload.ts
@@ -1,0 +1,126 @@
+/** Upload local media directly to an S3-compatible object store. */
+import { Command } from '@tauri-apps/api/shell';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+export interface S3UploadProgress {
+  stage: 'preparing' | 'uploading' | 'completed';
+  loadedBytes: number;
+  totalBytes: number;
+  percent: number;
+}
+
+function mimeFromExt(name: string): string {
+  const ext = name.split('.').pop()?.toLowerCase() ?? '';
+  const map: Record<string, string> = {
+    png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', webp: 'image/webp', gif: 'image/gif',
+    mp4: 'video/mp4', mov: 'video/quicktime', avi: 'video/x-msvideo', webm: 'video/webm',
+    mp3: 'audio/mpeg', wav: 'audio/wav', m4a: 'audio/mp4', ogg: 'audio/ogg',
+  };
+  return map[ext] ?? 'application/octet-stream';
+}
+
+function logUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url.split('?')[0];
+  }
+}
+
+export async function uploadToS3(
+  localPath: string,
+  fileName: string,
+  contentTypeOverride?: string,
+  onProgress?: (progress: S3UploadProgress) => void,
+): Promise<string> {
+  const state = useSettingsStore.getState();
+  const endpoint = state.s3Endpoint.trim();
+  const region = state.s3Region.trim() || 'us-east-1';
+  const bucket = state.s3Bucket.trim();
+  const accessKeyId = state.s3AccessKeyId.trim();
+  const secretAccessKey = state.s3SecretAccessKey.trim();
+  const prefix = state.s3Prefix.trim().replace(/^\/+|\/+$/g, '');
+  const publicBaseUrl = state.s3PublicBaseUrl.trim().replace(/\/$/, '');
+
+  if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
+    throw new Error('请先完整配置 S3 Endpoint、Bucket、Access Key 和 Secret Key');
+  }
+
+  const safeName = fileName.replace(/[^a-zA-Z0-9._-]/g, '_');
+  const key = `${prefix ? `${prefix}/` : ''}${Date.now()}_${safeName}`;
+  const contentType = contentTypeOverride || mimeFromExt(fileName);
+  const startedAt = Date.now();
+  console.info('[s3] upload:start', { endpoint: logUrl(endpoint), bucket, key, contentType });
+  onProgress?.({ stage: 'preparing', loadedBytes: 0, totalBytes: 0, percent: 0 });
+
+  const pyScript = `
+import os, sys, subprocess
+try:
+    import boto3
+    from botocore.config import Config
+except ImportError:
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--user', '-q', 'boto3'])
+    import boto3
+    from botocore.config import Config
+
+client = boto3.client(
+    's3', endpoint_url=os.environ['S3_ENDPOINT'], region_name=os.environ['S3_REGION'],
+    aws_access_key_id=os.environ['S3_ACCESS_KEY_ID'], aws_secret_access_key=os.environ['S3_SECRET_ACCESS_KEY'],
+    config=Config(signature_version='s3v4', s3={'addressing_style': 'path' if os.environ.get('S3_FORCE_PATH_STYLE') == '1' else 'auto'}),
+)
+with open(sys.argv[1], 'rb') as file_obj:
+    client.upload_fileobj(file_obj, os.environ['S3_BUCKET'], os.environ['S3_KEY'], ExtraArgs={'ContentType': os.environ['S3_CONTENT_TYPE']})
+print('OK', flush=True)
+`.trim();
+
+  const buildCommand = (program: string) => new Command(program, ['-X', 'utf8', '-c', pyScript, localPath], {
+    env: {
+      S3_ENDPOINT: endpoint,
+      S3_REGION: region,
+      S3_BUCKET: bucket,
+      S3_KEY: key,
+      S3_ACCESS_KEY_ID: accessKeyId,
+      S3_SECRET_ACCESS_KEY: secretAccessKey,
+      S3_CONTENT_TYPE: contentType,
+      S3_FORCE_PATH_STYLE: state.s3ForcePathStyle ? '1' : '0',
+      PYTHONUTF8: '1',
+      PYTHONIOENCODING: 'utf-8',
+    },
+  });
+  const runWithPython = (program: string) => new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+    const command = buildCommand(program);
+    let stdout = '';
+    let stderr = '';
+    command.stdout.on('data', (chunk: string) => { stdout += chunk; });
+    command.stderr.on('data', (chunk: string) => { stderr += chunk; });
+    command.on('error', reject);
+    command.on('close', (result) => resolve({ ...result, stdout, stderr }));
+    command.spawn().catch(reject);
+  });
+
+  try {
+    let result;
+    try {
+      result = await runWithPython('python3');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (!/program not found|not found|ENOENT|无法找到/i.test(message)) throw err;
+      result = await runWithPython('python');
+    }
+    if (result.code !== 0 || !result.stdout.includes('OK')) {
+      throw new Error(result.stderr.trim() || result.stdout.trim() || 'S3 上传进程失败');
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[s3] upload:failed', { endpoint: logUrl(endpoint), bucket, elapsedMs: Date.now() - startedAt, error: message });
+    throw new Error(`S3 上传失败: ${message.slice(0, 300)}`);
+  }
+
+  const baseUrl = publicBaseUrl || endpoint;
+  const publicUrl = `${baseUrl}/${encodeURIComponent(bucket)}/${key.split('/').map(encodeURIComponent).join('/')}`;
+  console.info('[s3] upload:success', { bucket, key, url: logUrl(publicUrl), elapsedMs: Date.now() - startedAt });
+  onProgress?.({ stage: 'uploading', loadedBytes: 1, totalBytes: 1, percent: 100 });
+  onProgress?.({ stage: 'completed', loadedBytes: 1, totalBytes: 1, percent: 100 });
+  return publicUrl;
+}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -295,6 +295,24 @@ interface SettingsState {
   setCosSecretKey: (v: string) => void;
   setCosTransitEndpoint: (v: string) => void;
 
+  // Generic S3-compatible media storage
+  s3Endpoint: string;
+  s3Region: string;
+  s3Bucket: string;
+  s3AccessKeyId: string;
+  s3SecretAccessKey: string;
+  s3Prefix: string;
+  s3PublicBaseUrl: string;
+  s3ForcePathStyle: boolean;
+  setS3Endpoint: (v: string) => void;
+  setS3Region: (v: string) => void;
+  setS3Bucket: (v: string) => void;
+  setS3AccessKeyId: (v: string) => void;
+  setS3SecretAccessKey: (v: string) => void;
+  setS3Prefix: (v: string) => void;
+  setS3PublicBaseUrl: (v: string) => void;
+  setS3ForcePathStyle: (v: boolean) => void;
+
   // Optional display name used in greetings (「你好！」 when empty).
   // Private builds can preset it via private.defaults.json (gitignored).
   greetingName: string;
@@ -517,6 +535,23 @@ export const useSettingsStore = create<SettingsState>()(
         ...mirrorCredentialWrite(s, 'cos', `${s.cosSecretId}:${cosSecretKey}`),
       })),
       setCosTransitEndpoint: (cosTransitEndpoint) => set({ cosTransitEndpoint }),
+      // Generic S3-compatible media storage
+      s3Endpoint: '',
+      s3Region: 'us-east-1',
+      s3Bucket: '',
+      s3AccessKeyId: '',
+      s3SecretAccessKey: '',
+      s3Prefix: 'kunpeng',
+      s3PublicBaseUrl: '',
+      s3ForcePathStyle: true,
+      setS3Endpoint: (s3Endpoint) => set({ s3Endpoint }),
+      setS3Region: (s3Region) => set({ s3Region }),
+      setS3Bucket: (s3Bucket) => set({ s3Bucket }),
+      setS3AccessKeyId: (s3AccessKeyId) => set({ s3AccessKeyId }),
+      setS3SecretAccessKey: (s3SecretAccessKey) => set({ s3SecretAccessKey }),
+      setS3Prefix: (s3Prefix) => set({ s3Prefix }),
+      setS3PublicBaseUrl: (s3PublicBaseUrl) => set({ s3PublicBaseUrl }),
+      setS3ForcePathStyle: (s3ForcePathStyle) => set({ s3ForcePathStyle }),
       greetingName: '',
       setGreetingName: (greetingName) => set({ greetingName }),
 


### PR DESCRIPTION
## 关联 Issue

Closes #15
Closes #16

## 变更内容

- 在设置页新增标准 S3 兼容存储配置：Endpoint、Region、Bucket、Access Key、Secret Key、对象前缀、公开 URL 和 Path-style。
- 保留腾讯云 COS 现有配置；未填写 S3 Endpoint 时行为不变。
- 复用现有媒体上传入口，配置 S3 后直接上传图片、视频和音频到 S3/MinIO/R2 等服务。
- 使用 boto3 的 SigV4 上传；凭据通过进程环境变量传递，不放入命令行参数或日志。
- Windows 优先尝试 `python3`，不存在时回退到 `python`。
- Access Key 和 Secret Access Key 标记为凭证字段，分享设置导出时会被过滤。
- 修复 COS 中转脚本实际对象 key 与返回 URL 不一致导致的 `NoSuchKey`：支持 `COS_OBJECT_PREFIX`，返回 `cosKey`，并确保上传路径与 URL 使用同一个 key。

## 验证

- `git diff --check`
- Python SCF 文件编译检查
- `tsc --noEmit`
- `vite build`

构建通过；Vite 仅报告仓库已有的动态导入和大 chunk 警告。

## 使用方式

在“设置 → 存储与集成 → 自定义 S3 兼容存储”填写 Endpoint、Region、Bucket、Access Key ID 和 Secret Access Key；填写 Endpoint 后自动启用 S3 直传。对于 MinIO、R2 等服务可启用 Path-style，并可填写公开 CDN 基础 URL。

COS 中转函数新增可选环境变量 `COS_OBJECT_PREFIX`，默认值为 `kunpeng`。